### PR TITLE
fixed failed spec with rspec 3.1.0

### DIFF
--- a/spec/tdiary/io/rdb_spec.rb
+++ b/spec/tdiary/io/rdb_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe TDiary::IO::Rdb do
   it 'is_a TDiary::IO::Base' do
-    expect { TDiary::IO::Rdb.is_a?(TDiary::IO::Base) }.to be_true
+    expect(TDiary::IO::Rdb.new(DummyTDiary.new)).to be_a(TDiary::IO::Base)
   end
 
   describe "#save_cgi_conf and #load_cgi_conf" do

--- a/tdiary-io-rdb.gemspec
+++ b/tdiary-io-rdb.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", "~> 3.1.0"
 end


### PR DESCRIPTION
rspec 3.1.0 で以下のように spec が落ちていたので修正しました。
(spec と gemspec の development_dependency のみの修正で、実行時の問題があったわけではないです)

```
% bundle exec rake spec 
/usr/bin/ruby2.1 -I/home/debian/go/src/github.com/tdiary/tdiary-io-rdb/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.7/lib:/home/debian/go/src/github.com/tdiary/tdiary-io-rdb/vendor/bundle/ruby/2.1.0/gems/rspec-support-3.1.2/lib /home/debian/go/src/github.com/tdiary/tdiary-io-rdb/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.7/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb

TDiary::IO::Rdb
  is_a TDiary::IO::Base (FAILED - 1)
  #save_cgi_conf and #load_cgi_conf
    should be empty
    given body
      should eq "foo"
      update
        should eq "bar"
  #transaction
    insert diary
    restore diary
    update diary
      update contents of diary

Failures:

  1) TDiary::IO::Rdb is_a TDiary::IO::Base
     Failure/Error: expect { TDiary::IO::Rdb.is_a?(TDiary::IO::Base) }.to be_true
       You must pass an argument rather than a block to use the provided matcher (be true), or the matcher must implement `supports_block_expectations?`.
     # ./spec/tdiary/io/rdb_spec.rb:5:in `block (2 levels) in <top (required)>'

Finished in 0.25329 seconds (files took 0.1631 seconds to load)
7 examples, 1 failure

Failed examples:

rspec ./spec/tdiary/io/rdb_spec.rb:4 # TDiary::IO::Rdb is_a TDiary::IO::Base
/usr/bin/ruby2.1 -I/home/debian/go/src/github.com/tdiary/tdiary-io-rdb/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.7/lib:/home/debian/go/src/github.com/tdiary/tdiary-io-rdb/vendor/bundle/ruby/2.1.0/gems/rspec-support-3.1.2/lib /home/debian/go/src/github.com/tdiary/tdiary-io-rdb/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.7/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
```

以前の Travis のビルド https://travis-ci.org/tdiary/tdiary-io-rdb/builds/16095739 を見ると fail して
いませんでしたが、当時の rspec 2.14.1 では `expect { ... }.to be_true` のようにexpectにブロックを
渡しても、ブロックが実行されていなかったようです。
