### PR TITLE
DB接続が切断されたときにテーブルの存在チェックを誤ってしまう問題の修正

### DIFF
--- a/lib/tdiary/io/rdb.rb
+++ b/lib/tdiary/io/rdb.rb
@@ -92,7 +92,12 @@ module TDiary
         end
 
         def db(conf)
-          @@_db ||= Sequel.connect(conf.database_url || ENV['DATABASE_URL'])
+          @@_db ||= Sequel.connect(conf.database_url || ENV['DATABASE_URL']).tap{|db|
+            db.extension(:connection_validator)
+            db.pool.connection_validation_timeout = -1
+          }
+
+          @@_db.test_connection
 
           @@_db.create_table :conf do
             String :body, text: true


### PR DESCRIPTION
DBとしてMySQLを使っている場合、数時間程度時間をあけてtdiaryにアクセスすると、

```
Sequel::DatabaseError: Mysql2::Error: Table 'conf' already exists
/usr/local/bundle/gems/mysql2-0.4.0/lib/mysql2/client.rb:87:in `_query'
/usr/local/bundle/gems/mysql2-0.4.0/lib/mysql2/client.rb:87:in `block in query'
/usr/local/bundle/gems/mysql2-0.4.0/lib/mysql2/client.rb:86:in `handle_interrupt'
/usr/local/bundle/gems/mysql2-0.4.0/lib/mysql2/client.rb:86:in `query'
/usr/local/bundle/gems/sequel-4.25.0/lib/sequel/adapters/mysql2.rb:78:in `block in _execute'
/usr/local/bundle/gems/sequel-4.25.0/lib/sequel/database/logging.rb:33:in `log_yield'
/usr/local/bundle/gems/sequel-4.25.0/lib/sequel/adapters/mysql2.rb:78:in `_execute'
/usr/local/bundle/gems/sequel-4.25.0/lib/sequel/adapters/shared/mysql_prepared_statements.rb:34:in `block in execute'
/usr/local/bundle/gems/sequel-4.25.0/lib/sequel/database/connecting.rb:249:in `block in synchronize'
/usr/local/bundle/gems/sequel-4.25.0/lib/sequel/connection_pool/threaded.rb:103:in `hold'
/usr/local/bundle/gems/sequel-4.25.0/lib/sequel/database/connecting.rb:249:in `synchronize'
/usr/local/bundle/gems/sequel-4.25.0/lib/sequel/adapters/shared/mysql_prepared_statements.rb:34:in `execute'
/usr/local/bundle/gems/sequel-4.25.0/lib/sequel/adapters/mysql2.rb:57:in `execute_dui'
/usr/local/bundle/gems/sequel-4.25.0/lib/sequel/database/query.rb:43:in `execute_ddl'
/usr/local/bundle/gems/sequel-4.25.0/lib/sequel/database/schema_methods.rb:643:in `create_table_from_generator'
/usr/local/bundle/gems/sequel-4.25.0/lib/sequel/database/schema_methods.rb:195:in `create_table'
/usr/local/bundle/bundler/gems/tdiary-io-rdb-f7f7024bd042/lib/tdiary/io/rdb.rb:97:in `db'
/usr/local/bundle/bundler/gems/tdiary-io-rdb-f7f7024bd042/lib/tdiary/io/rdb.rb:79:in `load_cgi_conf'
/usr/src/app/lib/tdiary/configuration.rb:114:in `load_cgi_conf'
(tdiary.conf):260:in `configure_attrs'
/usr/src/app/lib/tdiary/configuration.rb:141:in `eval'
/usr/src/app/lib/tdiary/configuration.rb:141:in `configure_attrs'
/usr/src/app/lib/tdiary/configuration.rb:12:in `initialize'
/usr/src/app/lib/tdiary/dispatcher/index_main.rb:14:in `new'
/usr/src/app/lib/tdiary/dispatcher/index_main.rb:14:in `initialize'
/usr/src/app/lib/tdiary/dispatcher/index_main.rb:6:in `new'
/usr/src/app/lib/tdiary/dispatcher/index_main.rb:6:in `run'
/usr/src/app/lib/tdiary/dispatcher.rb:26:in `dispatch_cgi'
/usr/src/app/lib/tdiary/dispatcher.rb:21:in `call'
/usr/src/app/lib/tdiary/rack/valid_request_path.rb:17:in `block in call'
/usr/src/app/lib/tdiary/rack/valid_request_path.rb:16:in `each'
/usr/src/app/lib/tdiary/rack/valid_request_path.rb:16:in `call'
/usr/src/app/lib/tdiary/rack/static.rb:15:in `call'
/usr/src/app/lib/tdiary/rack/html_anchor.rb:20:in `call'
/usr/local/bundle/gems/rack-1.6.4/lib/rack/urlmap.rb:66:in `block in call'
/usr/local/bundle/gems/rack-1.6.4/lib/rack/urlmap.rb:50:in `each'
/usr/local/bundle/gems/rack-1.6.4/lib/rack/urlmap.rb:50:in `call'
/usr/local/bundle/gems/rack-1.6.4/lib/rack/urlmap.rb:66:in `block in call'
/usr/local/bundle/gems/rack-1.6.4/lib/rack/urlmap.rb:50:in `each'
/usr/local/bundle/gems/rack-1.6.4/lib/rack/urlmap.rb:50:in `call'
/usr/src/app/lib/tdiary/application.rb:64:in `call'
/usr/local/bundle/gems/puma-2.13.4/lib/puma/configuration.rb:78:in `call'
/usr/local/bundle/gems/puma-2.13.4/lib/puma/server.rb:541:in `handle_request'
/usr/local/bundle/gems/puma-2.13.4/lib/puma/server.rb:388:in `process_client'
/usr/local/bundle/gems/puma-2.13.4/lib/puma/server.rb:270:in `block in run'
/usr/local/bundle/gems/puma-2.13.4/lib/puma/thread_pool.rb:106:in `call'
/usr/local/bundle/gems/puma-2.13.4/lib/puma/thread_pool.rb:106:in `block in spawn_thread'
```

という例外が発生することがあります。

例外が起きているのは https://github.com/tdiary/tdiary-io-rdb/blob/v0.0.1/lib/tdiary/io/rdb.rb#L94-L99 の

```ruby
        def db(conf)
          @@_db ||= Sequel.connect(conf.database_url || ENV['DATABASE_URL'])

          @@_db.create_table :conf do
            String :body, text: true
          end unless @@_db.table_exists?(:conf)
```

のところで、DBには conf テーブルが存在するのに、`@@_db.table_exists?(:conf)` が false を返したようで、
conf テーブルを作成しようとして例外が起きたらしい、という状況でした。

調べてみたところ、何らかの理由でMySQLサーバ側がコネクションを切断した場合、
`Sequel::Database#table_exists?` が false を返してしまう、ということが分かりました。

```
[1] pry(main)> require 'logger'
=> true
[2] pry(main)> require 'sequel'
=> true
[3] pry(main)> logger = Logger.new($stdout).tap{|o| o.level = Logger::DEBUG }; nil
=> nil
[4] pry(main)> db = Sequel.connect("mysql2://tdiary:tdiary@172.17.0.38:3306/tdiary"); nil
=> nil
[5] pry(main)> db.logger = logger; nil
=> nil
[6] pry(main)> db.table_exists?(:conf)
I, [2015-09-17T00:56:14.891045 #13790]  INFO -- : (0.000113s) SET @@wait_timeout = 2147483
I, [2015-09-17T00:56:14.891228 #13790]  INFO -- : (0.000116s) SET SQL_AUTO_IS_NULL=0
I, [2015-09-17T00:56:14.891495 #13790]  INFO -- : (0.000195s) SELECT NULL AS `nil` FROM `conf` LIMIT 1
=> true

#
# ここで mysql -u root -h x.x.x.x -p mysql から show processlist を実行して Sequel からのコネクションを探し、
# kill connection ID で MySQLサーバ側から切断
#

[7] pry(main)> db.table_exists?(:conf)
E, [2015-09-17T00:56:23.405873 #13790] ERROR -- : Mysql2::Error: Lost connection to MySQL server during query: SELECT NULL AS `nil` FROM `conf` LIMIT 1
=> false
[8] pry(main)> db.table_exists?(:conf)
I, [2015-09-17T00:56:26.256683 #13790]  INFO -- : (0.000085s) SET @@wait_timeout = 2147483
I, [2015-09-17T00:56:26.256878 #13790]  INFO -- : (0.000134s) SET SQL_AUTO_IS_NULL=0
I, [2015-09-17T00:56:26.257134 #13790]  INFO -- : (0.000197s) SELECT NULL AS `nil` FROM `conf` LIMIT 1
=> true
```

そこで http://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_validator_rb.html を
利用してみました。pry での検証は以下のようになりました。

```
[9] pry(main)> db.extension(:connection_validator)
=> #<Sequel::Mysql2::Database: "mysql2://tdiary:tdiary@172.17.0.38:3306/tdiary">
[10] pry(main)> db.pool.connection_validation_timeout = -1
=> -1
[11] pry(main)> db.table_exists?(:conf)
I, [2015-09-17T00:59:45.454835 #13790]  INFO -- : (0.000273s) SELECT NULL AS `nil` FROM `conf` LIMIT 1
=> true

#
# ここで上記と同様に kill connection ID で Sequel からのコネクションを切断
#

[12] pry(main)> db.table_exists?(:conf)
E, [2015-09-17T00:59:56.859638 #13790] ERROR -- : Mysql2::Error: Lost connection to MySQL server during query: SELECT NULL
I, [2015-09-17T00:59:56.860161 #13790]  INFO -- : (0.000071s) SET @@wait_timeout = 2147483
I, [2015-09-17T00:59:56.860316 #13790]  INFO -- : (0.000114s) SET SQL_AUTO_IS_NULL=0
I, [2015-09-17T00:59:56.860562 #13790]  INFO -- : (0.000181s) SELECT NULL AS `nil` FROM `conf` LIMIT 1
=> true
[13] pry(main)> db.table_exists?(:conf)
I, [2015-09-17T01:05:42.092047 #13790]  INFO -- : (0.000192s) SELECT NULL
I, [2015-09-17T01:05:42.092256 #13790]  INFO -- : (0.000155s) SELECT NULL AS `nil` FROM `conf` LIMIT 1
=> true
```

ひとまず手元の MySQL で動作確認中です。
