### PR TITLE
fixed `Duplicate column name 'diary_id'` error on creating diaries table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: ruby
+sudo: false
 rvm:
   - 2.0.0
-  - 1.9.3
+  - 2.1
+  - 2.2
+  - 2.3.0
+  - ruby-head
 script: bundle exec rspec spec

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TDiary::IO::Rdb
 
+[![Gem Version](https://badge.fury.io/rb/tdiary-io-rdb.png)](https://rubygems.org/gems/tdiary-io-rdb) [![Build Status](https://secure.travis-ci.org/tdiary/tdiary-io-rdb.png)](https://travis-ci.org/tdiary/tdiary-io-rdb)
+
 RDB like sqlite, mysql and postgresql adapter for tDiary
 
 ## Installation

--- a/lib/tdiary/io/rdb.rb
+++ b/lib/tdiary/io/rdb.rb
@@ -104,7 +104,7 @@ module TDiary
           end unless @@_db.table_exists?(:conf)
 
           @@_db.create_table :diaries do
-            String :diary_id, size: 8
+            String :diary_id, size: 8, primary_key: true
             String :year, size: 4
             String :month, size: 2
             String :day, size: 2
@@ -113,7 +113,6 @@ module TDiary
             String :style, text: true
             Fixnum :last_modified
             TrueClass :visible
-            primary_key :diary_id
           end unless @@_db.table_exists?(:diaries)
 
           @@_db.create_table :comments do


### PR DESCRIPTION
With sequel 4.27.0 or later, `Duplicate column name 'diary_id'` error happens on creating diaries table.

```
% git clone git://github.com/tdiary/tdiary-core.git
% cd tdiary-core
% mkdir -p vendor/bundle
% echo "gem 'tdiary-io-rdb'" > Gemfile.local
% echo "gem 'sqlite3'" >> Gemfile.local
% bundle install --path vendor/bundle
% ( echo '@io_class = TDiary::IO::Rdb if ENV["DATABASE_URL"]'; cat tdiary.conf.beginner ) > tdiary.conf
% export DATABASE_URL=sqlite:///tmp/tdiary.db
% bundle exec bin/tdiary server
/home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/sqlite3-1.3.11/lib/sqlite3/database.rb:91:in `initialize': SQLite3::SQLException: duplicate column name: diary_id (Sequel::DatabaseError)
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/sqlite3-1.3.11/lib/sqlite3/database.rb:91:in `new'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/sqlite3-1.3.11/lib/sqlite3/database.rb:91:in `prepare'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/sqlite3-1.3.11/lib/sqlite3/database.rb:223:in `execute_batch'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/sequel-4.29.0/lib/sequel/adapters/sqlite.rb:190:in `block (2 levels) in _execute'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/sequel-4.29.0/lib/sequel/database/logging.rb:33:in `log_yield'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/sequel-4.29.0/lib/sequel/adapters/sqlite.rb:190:in `block in _execute'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/sequel-4.29.0/lib/sequel/database/connecting.rb:249:in `block in synchronize'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/sequel-4.29.0/lib/sequel/connection_pool/threaded.rb:99:in `hold'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/sequel-4.29.0/lib/sequel/database/connecting.rb:249:in `synchronize'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/sequel-4.29.0/lib/sequel/adapters/sqlite.rb:178:in `_execute'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/sequel-4.29.0/lib/sequel/adapters/sqlite.rb:133:in `execute_dui'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/sequel-4.29.0/lib/sequel/database/query.rb:43:in `execute_ddl'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/sequel-4.29.0/lib/sequel/adapters/sqlite.rb:143:in `block in execute_ddl'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/sequel-4.29.0/lib/sequel/database/connecting.rb:249:in `block in synchronize'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/sequel-4.29.0/lib/sequel/connection_pool/threaded.rb:103:in `hold'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/sequel-4.29.0/lib/sequel/database/connecting.rb:249:in `synchronize'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/sequel-4.29.0/lib/sequel/adapters/sqlite.rb:140:in `execute_ddl'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/sequel-4.29.0/lib/sequel/database/schema_methods.rb:661:in `create_table_from_generator'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/sequel-4.29.0/lib/sequel/database/schema_methods.rb:195:in `create_table'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/tdiary-io-rdb-0.0.1/lib/tdiary/io/rdb.rb:101:in `db'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/tdiary-io-rdb-0.0.1/lib/tdiary/io/rdb.rb:79:in `load_cgi_conf'
	from /home/debian/tdiary-core/lib/tdiary/configuration.rb:116:in `load_cgi_conf'
	from (tdiary.conf):245:in `configure_attrs'
	from /home/debian/tdiary-core/lib/tdiary/configuration.rb:143:in `eval'
	from /home/debian/tdiary-core/lib/tdiary/configuration.rb:143:in `configure_attrs'
	from /home/debian/tdiary-core/lib/tdiary/configuration.rb:12:in `initialize'
	from /home/debian/tdiary-core/lib/tdiary.rb:134:in `new'
	from /home/debian/tdiary-core/lib/tdiary.rb:134:in `configuration'
	from /home/debian/tdiary-core/lib/tdiary/application.rb:79:in `index_path'
	from /home/debian/tdiary-core/lib/tdiary/application.rb:19:in `initialize'
	from /home/debian/tdiary-core/config.ru:5:in `new'
	from /home/debian/tdiary-core/config.ru:5:in `block in <main>'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/rack-1.6.4/lib/rack/builder.rb:55:in `instance_eval'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/rack-1.6.4/lib/rack/builder.rb:55:in `initialize'
	from /home/debian/tdiary-core/config.ru:in `new'
	from /home/debian/tdiary-core/config.ru:in `<main>'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/rack-1.6.4/lib/rack/builder.rb:49:in `eval'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/rack-1.6.4/lib/rack/builder.rb:49:in `new_from_string'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/rack-1.6.4/lib/rack/builder.rb:40:in `parse_file'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/rack-1.6.4/lib/rack/server.rb:299:in `build_app_and_options_from_config'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/rack-1.6.4/lib/rack/server.rb:208:in `app'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/rack-1.6.4/lib/rack/server.rb:336:in `wrapped_app'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/rack-1.6.4/lib/rack/server.rb:272:in `start'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/rack-1.6.4/lib/rack/server.rb:147:in `start'
	from /home/debian/tdiary-core/lib/tdiary/cli.rb:130:in `server'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
	from /home/debian/tdiary-core/vendor/bundle/ruby/2.2.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
	from bin/tdiary:7:in `<main>'
```


