### PR TITLE
Bump up the version to 0.0.2

### DIFF
--- a/tdiary-io-rdb.gemspec
+++ b/tdiary-io-rdb.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "tdiary-io-rdb"
-  spec.version       = "0.0.1"
+  spec.version       = "0.0.2"
   spec.authors       = ["SHIBATA Hiroshi"]
   spec.email         = ["shibata.hiroshi@gmail.com"]
   spec.summary       = %q{rdb adapter for tDiary}


### PR DESCRIPTION
現在、rubygems.orgから取得できるversion 0.0.1 だと、`TDiary::Comment`を参照する際に名前空間を正しく解決できず、エラーになります。[[参考]](http://diary-satoryu.rhcloud.com/201407.html)

現在のgithub上のmaster では、既に解決されているので、バージョンを上げて、リリースした方が良いのではないでしょうか。
